### PR TITLE
Updated cachet.coffee to fix 'hubot incident last'

### DIFF
--- a/src/cachet.coffee
+++ b/src/cachet.coffee
@@ -91,15 +91,17 @@ module.exports = (robot) ->
   ###
   Call the API to declare a new incident
   ###
-  declareIncident = (component_name, incident_name, incident_msg, status, msg, scheduled_at) ->
+  declareIncident = (component_name, component_status, incident_name, incident_msg, status, msg, scheduled_at) ->
     component_id  = _components[component_name] ? 0
     incident_name = component_name if component_id == 0 unless not component_name?
 
     data = {
+      visible: 1,
       name: incident_name,
       message: incident_msg,
       status: status,
       component_id: component_id,
+      component_status: component_status,
       notify: true
     }
 
@@ -223,32 +225,36 @@ module.exports = (robot) ->
     component_name = msg.match[1]
     incident_msg   = msg.match[2]
     incident_name  = "Investigating issue on #{component_name}"
+    component_status = ComponentStatus.PartialOutage
 
-    declareIncident component_name, incident_name, incident_msg, \
+    declareIncident component_name, component_status, incident_name, incident_msg, \
                      IncidentStatus.Investigating, msg
 
   robot.respond /incident identified on ([a-zA-Z0-9 ]+): (.+)/i, (msg) ->
     component_name = msg.match[1]
     incident_msg   = msg.match[2]
     incident_name  = "Issue on #{component_name} has been identified"
+    component_status = ComponentStatus.MajorOutage
 
-    declareIncident component_name, incident_name, incident_msg, \
+    declareIncident component_name, component_status, incident_name, incident_msg, \
                      IncidentStatus.Identified, msg
 
   robot.respond /incident watching on ([a-zA-Z0-9 ]+): (.+)/i, (msg) ->
     component_name = msg.match[1]
     incident_msg   = msg.match[2]
     incident_name  = "Watching #{component_name}"
+    component_status = ComponentStatus.PerformanceIssue
 
-    declareIncident component_name, incident_name, incident_msg, \
+    declareIncident component_name, component_status, incident_name, incident_msg, \
                      IncidentStatus.Watching, msg
 
   robot.respond /incident fixed on ([a-zA-Z0-9 ]+): (.+)/i, (msg) ->
     component_name = msg.match[1]
     incident_msg   = msg.match[2]
     incident_name  = "#{component_name} is back!"
+    component_status = ComponentStatus.Operational
 
-    declareIncident component_name, incident_name, incident_msg, \
+    declareIncident component_name, component_status, incident_name, incident_msg, \
                      IncidentStatus.Fixed, msg
 
   robot.respond /cachet maintenance at (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (.+): (.+)/i, (msg) ->

--- a/src/cachet.coffee
+++ b/src/cachet.coffee
@@ -261,8 +261,9 @@ module.exports = (robot) ->
     scheduled_at  = msg.match[1]
     incident_name = msg.match[2]
     incident_msg  = msg.match[3]
+    component_status = ComponentStatus.Operational
 
-    declareIncident null, null, incident_name, incident_msg, \
+    declareIncident null, component_status, incident_name, incident_msg, \
                      IncidentStatus.Scheduled, msg, scheduled_at
 
   robot.respond /incident #?([0-9]+) update name: (.+)/i, (msg) ->

--- a/src/cachet.coffee
+++ b/src/cachet.coffee
@@ -110,7 +110,7 @@ module.exports = (robot) ->
 
     data = JSON.stringify data
 
-    apiRequest msg, 'POST', '/api/v1/incidents', data, (body) ->
+    apiRequest msg, 'POST', '/incidents', data, (body) ->
       json     = JSON.parse body
       incident = json.data
 
@@ -125,7 +125,7 @@ module.exports = (robot) ->
   updateIncident = (incident_id, data, msg) ->
     data = JSON.stringify data
 
-    apiRequest msg, 'PUT', "/api/v1/incidents/#{incident_id}", data, (body) ->
+    apiRequest msg, 'PUT', "/incidents/#{incident_id}", data, (body) ->
       json     = JSON.parse body
       incident = json.data
 
@@ -154,7 +154,7 @@ module.exports = (robot) ->
 
     data = JSON.stringify { status: status }
 
-    apiRequest msg, 'PUT', "/api/v1/components/#{component_id}", data, (body) ->
+    apiRequest msg, 'PUT', "/components/#{component_id}", data, (body) ->
       json     = JSON.parse body
       component = json.data
 
@@ -175,7 +175,7 @@ module.exports = (robot) ->
     changeComponentStatus component_name, status, msg
 
   robot.respond /cachet component status/i, (msg) ->
-    apiRequest msg, 'GET', '/api/v1/components', {}, (body) ->
+    apiRequest msg, 'GET', '/components', {}, (body) ->
       json = JSON.parse body
 
       results = []
@@ -294,7 +294,7 @@ module.exports = (robot) ->
     if not nb?
       nb = 5
 
-    apiRequest msg, 'GET', "/api/v1/incidents?sort=id&per_page=#{nb}",
+    apiRequest msg, 'GET', "/incidents?sort=id&per_page=#{nb}",
       {}, (body) ->
         json      = JSON.parse body
         incidents = json.data

--- a/src/cachet.coffee
+++ b/src/cachet.coffee
@@ -110,7 +110,7 @@ module.exports = (robot) ->
 
     data = JSON.stringify data
 
-    apiRequest msg, 'POST', '/incidents', data, (body) ->
+    apiRequest msg, 'POST', '/api/v1/incidents', data, (body) ->
       json     = JSON.parse body
       incident = json.data
 
@@ -125,7 +125,7 @@ module.exports = (robot) ->
   updateIncident = (incident_id, data, msg) ->
     data = JSON.stringify data
 
-    apiRequest msg, 'PUT', "/incidents/#{incident_id}", data, (body) ->
+    apiRequest msg, 'PUT', "/api/v1/incidents/#{incident_id}", data, (body) ->
       json     = JSON.parse body
       incident = json.data
 
@@ -154,7 +154,7 @@ module.exports = (robot) ->
 
     data = JSON.stringify { status: status }
 
-    apiRequest msg, 'PUT', "/components/#{component_id}", data, (body) ->
+    apiRequest msg, 'PUT', "/api/v1/components/#{component_id}", data, (body) ->
       json     = JSON.parse body
       component = json.data
 
@@ -175,7 +175,7 @@ module.exports = (robot) ->
     changeComponentStatus component_name, status, msg
 
   robot.respond /cachet component status/i, (msg) ->
-    apiRequest msg, 'GET', '/components', {}, (body) ->
+    apiRequest msg, 'GET', '/api/v1/components', {}, (body) ->
       json = JSON.parse body
 
       results = []
@@ -294,7 +294,7 @@ module.exports = (robot) ->
     if not nb?
       nb = 5
 
-    apiRequest msg, 'GET', "/incidents?sort=id&per_page=#{nb}",
+    apiRequest msg, 'GET', "/api/v1/incidents?sort=id&per_page=#{nb}",
       {}, (body) ->
         json      = JSON.parse body
         incidents = json.data

--- a/src/cachet.coffee
+++ b/src/cachet.coffee
@@ -262,7 +262,7 @@ module.exports = (robot) ->
     incident_name = msg.match[2]
     incident_msg  = msg.match[3]
 
-    declareIncident null, incident_name, incident_msg, \
+    declareIncident null, null, incident_name, incident_msg, \
                      IncidentStatus.Scheduled, msg, scheduled_at
 
   robot.respond /incident #?([0-9]+) update name: (.+)/i, (msg) ->

--- a/src/cachet.coffee
+++ b/src/cachet.coffee
@@ -288,7 +288,7 @@ module.exports = (robot) ->
     if not nb?
       nb = 5
 
-    apiRequest msg, 'GET', "/incidents?sort=created_at&order=desc&per_page=#{nb}",
+    apiRequest msg, 'GET', "/incidents?sort=id&per_page=#{nb}",
       {}, (body) ->
         json      = JSON.parse body
         incidents = json.data

--- a/test/cachet-test.coffee
+++ b/test/cachet-test.coffee
@@ -246,7 +246,7 @@ describe 'hubot cachet', ->
         message:"This is a maintenance message",
         status:0,
         component_id:0,
-        component_status:"null",
+        component_status:1,
         notify:true,
         scheduled_at: '2015-08-15 10:00:00'
       }

--- a/test/cachet-test.coffee
+++ b/test/cachet-test.coffee
@@ -95,10 +95,12 @@ describe 'hubot cachet', ->
   describe 'incident investigating on <component name>: <incident message>', ->
     it 'should allow to declare "investigating" incidents', (done) ->
       json = {
+        visible:1,
         name:"foo",
         message:"msg",
         status:1,
         component_id:0,
+        component_status:3,
         notify:true
       }
 
@@ -111,10 +113,12 @@ describe 'hubot cachet', ->
   describe 'incident identified on <component name>: <incident message>', ->
     it 'should allow to declare "identified" incidents', (done) ->
       json = {
+        visible:1,
         name:"foo",
         message:"msg",
         status:2,
         component_id:0,
+        component_status:4,
         notify:true
       }
 
@@ -127,10 +131,12 @@ describe 'hubot cachet', ->
   describe 'incident watching on <component name>: <incident message>', ->
     it 'should allow to declare "watching" incidents', (done) ->
       json = {
+        visible:1,
         name:"foo",
         message:"msg",
         status:3,
         component_id:0,
+        component_status:2,
         notify:true
       }
 
@@ -143,10 +149,12 @@ describe 'hubot cachet', ->
   describe 'incident fixed on <component name>: <incident message>', ->
     it 'should allow to declare "fixed" incidents', (done) ->
       json = {
+        visible:1,
         name:"foo",
         message:"msg",
         status:4,
         component_id:0,
+        component_status:1,
         notify:true
       }
 
@@ -164,10 +172,12 @@ describe 'hubot cachet', ->
 
     it 'should allow to declare incidents on known components', (done) ->
       json = {
+        visible:1,
         name:"foo is back!",
         message:"msg",
         status:4,
         component_id:3,
+        component_status:1,
         notify:true
       }
 
@@ -185,10 +195,12 @@ describe 'hubot cachet', ->
 
     it 'should deal with API errors', (done) ->
       json = {
+        visible:1,
         name:"foo is back!",
         message:"msg",
         status:4,
         component_id:3,
+        component_status:1,
         notify:true
       }
 
@@ -229,10 +241,12 @@ describe 'hubot cachet', ->
   describe 'cachet maintenance at <scheduled_at> <name>: <message>', ->
     it 'should create a new maintenance', (done) ->
       json = {
+        visible:1,
         name:"Foo is upgraded",
         message:"This is a maintenance message",
         status:0,
         component_id:0,
+        component_status:"null",
         notify:true,
         scheduled_at: '2015-08-15 10:00:00'
       }
@@ -363,7 +377,7 @@ describe 'hubot cachet', ->
       ]
 
       api
-        .get('/incidents?sort=created_at&order=desc&per_page=2')
+        .get('/incidents?sort=id&per_page=2')
         .reply(200, { data: incidents })
 
       helper.converse @robot, @user, '/incident last 2', (envelope, response) ->
@@ -383,7 +397,7 @@ describe 'hubot cachet', ->
       ]
 
       api
-        .get('/incidents?sort=created_at&order=desc&per_page=5')
+        .get('/incidents?sort=id&per_page=5')
         .reply(200, { data: incidents })
 
       helper.converse @robot, @user, '/incident last', (envelope, response) ->
@@ -398,7 +412,7 @@ describe 'hubot cachet', ->
 
     it 'should say when there are no incidents', (done) ->
       api
-        .get('/incidents?sort=created_at&order=desc&per_page=5')
+        .get('/incidents?sort=id&per_page=5')
         .reply(200, { data: [] })
 
       helper.converse @robot, @user, '/incident last 5', (envelope, response) ->
@@ -406,7 +420,7 @@ describe 'hubot cachet', ->
         done()
 
     it 'should deal with API errors', (done) ->
-      api.get('/incidents?sort=created_at&order=desc&per_page=5').reply(500)
+      api.get('/incidents?sort=id&per_page=5').reply(500)
 
       helper.converse @robot, @user, '/incident last', (envelope, response) ->
         assert.equal response, 'The request to the API has failed (status code = 500)'


### PR DESCRIPTION
Changes to cachet API seem to have broken the `order` function in sorting. Changes to use `id` rather than `created_at` which rolls through descending order.

Updated the DeclareIncident function as it now requires the visible field to be provided. 
Also the Component ID field can't be specified without also providing the Component Status

Updated URL to make use of new API address `/api/v1`